### PR TITLE
Add language constants to strings

### DIFF
--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -217,9 +217,12 @@ contexts:
   # https://www.terraform.io/docs/language/expressions/types.html#literal-expressions
   # https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md#literal-values
   language_constants:
-    - match: \b(true|false|null)\b
-      comment: Language Constants
-      scope: constant.language.terraform
+    - match: \btrue\b
+      scope: constant.language.boolean.true.terraform
+    - match: \bfalse\b
+      scope: constant.language.boolean.false.terraform
+    - match: \bnull\b
+      scope: constant.language.null.terraform
 
   # Numbers: Integers, fractions and exponents
   #
@@ -246,6 +249,31 @@ contexts:
   # https://www.terraform.io/docs/language/expressions/types.html
   # https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md#template-expressions
   string_literals:
+    - match: (")(true)(")
+      scope: string.quoted.double.terraform
+      captures:
+        1: punctuation.definition.string.begin.terraform
+        2: constant.language.boolean.true.terraform
+        3: punctuation.definition.string.end.terraform
+    - match: (")(false)(")
+      scope: string.quoted.double.terraform
+      captures:
+        1: punctuation.definition.string.begin.terraform
+        2: constant.language.boolean.false.terraform
+        3: punctuation.definition.string.end.terraform
+    - match: (")(none|null)(")
+      scope: string.quoted.double.terraform
+      captures:
+        1: punctuation.definition.string.begin.terraform
+        2: constant.language.null.terraform
+        3: punctuation.definition.string.end.terraform
+    - match: (")(-?)(\d+)(")
+      scope: string.quoted.double.terraform
+      captures:
+        1: punctuation.definition.string.begin.terraform
+        2: keyword.operator.arithmetic.terraform
+        3: meta.number.integer.terraform constant.numeric.value.terraform
+        4: punctuation.definition.string.end.terraform
     - match: '"'
       comment: Strings
       scope: punctuation.definition.string.begin.terraform

--- a/syntax_test_terraform-vars.tfvars
+++ b/syntax_test_terraform-vars.tfvars
@@ -24,7 +24,7 @@
 
     true
 # ^ -constant
-#   ^^^^ constant.language.terraform
+#   ^^^^ constant.language.boolean.true.terraform
 #         ^ -constant
 
     444

--- a/syntax_test_terraform.tf
+++ b/syntax_test_terraform.tf
@@ -89,7 +89,7 @@
 
     true
 # ^ -constant
-#   ^^^^ constant.language.terraform
+#   ^^^^ constant.language.boolean.true.terraform
 #         ^ -constant
 
 /////
@@ -98,7 +98,7 @@
 
     false
 # ^ -constant
-#   ^^^^^ constant.language.terraform
+#   ^^^^^ constant.language.boolean.false.terraform
 #         ^ -constant
 
 
@@ -108,7 +108,7 @@
 
     null
 # ^ -constant
-#   ^^^^ constant.language.terraform
+#   ^^^^ constant.language.null.terraform
 #         ^ -constant
 
 /////////////////////////////////////////////////////////////////////
@@ -327,9 +327,9 @@
 #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.terraform
 #      ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform
 #                 ^ keyword.operator.terraform
-#                   ^^^^ meta.interpolation.terraform constant.language.terraform
+#                   ^^^^ meta.interpolation.terraform constant.language.boolean.true.terraform
 #                        ^ meta.interpolation.terraform keyword.operator.terraform
-#                          ^^^^^ meta.interpolation.terraform constant.language.terraform
+#                          ^^^^^ meta.interpolation.terraform constant.language.boolean.false.terraform
 #                                ^ meta.interpolation.terraform punctuation.section.interpolation.end.terraform
 #                                 ^ string.quoted.double.terraform punctuation.definition.string.end.terraform
 
@@ -2399,8 +2399,18 @@
       tobool(true)
 #     ^^^^^^ meta.function-call.terraform support.function.builtin.terraform
 #           ^ meta.function-call.terraform punctuation.section.parens.begin.terraform
-#            ^^^^ meta.function-call.terraform constant.language.terraform
+#            ^^^^ meta.function-call.terraform constant.language.boolean.true.terraform
 #                ^ meta.function-call.terraform punctuation.section.parens.end.terraform
+
+      tobool("true")
+#     ^^^^^^^^^^^^^^ meta.function-call.terraform
+#     ^^^^^^ support.function.builtin.terraform
+#           ^ punctuation.section.parens.begin.terraform
+#            ^^^^^^ string.quoted.double.terraform
+#            ^ punctuation.definition.string.begin.terraform
+#             ^^^^ constant.language.boolean.true.terraform
+#                 ^ punctuation.definition.string.end.terraform
+#                  ^ punctuation.section.parens.end.terraform
 
       tolist(["a", "b", "c"])
 #     ^^^^^^ meta.function-call.terraform support.function.builtin.terraform


### PR DESCRIPTION
I could imagine dispute about adding perceived types inside strings, but I find it very helpful.