### PR TITLE
Make JSON (Terraform) visible

### DIFF
--- a/JSON (Terraform).sublime-syntax
+++ b/JSON (Terraform).sublime-syntax
@@ -4,7 +4,6 @@
 name: JSON (Terraform)
 scope: source.json.terraform
 version: 2
-hidden: true
 
 extends: Packages/JSON/JSON.sublime-syntax
 

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -451,7 +451,7 @@ contexts:
             2: keyword.operator.terraform
           set: object_value
         - include: expressions
-    - include: scope:source.json.terraform#object-body
+    - include: Packages/Terraform/JSON (Terraform).sublime-syntax#object-body
 
   object_key:
     - match: '{{identifier}}'


### PR DESCRIPTION
This commit turns JSON (Terraform) into a visible syntax as it has a file extension assigned.

Note: Hidden file causes A File Icon dummy to take precedence, breaking syntax highlighting.

To avoid it, absolute path is used to include _JSON (Terraform)_ syntax in Terraform.