### PR TITLE
Scope `in` as `keyword.control` again

### DIFF
--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -349,7 +349,7 @@ contexts:
     - match: \bendfor\b
       scope: keyword.control.loop.end.terraform
     - match: \bin\b
-      scope: keyword.operator.iteration.in.terraform
+      scope: keyword.control.loop.in.terraform
     - include: expressions
 
   # String Heredocs

--- a/tests/syntax_test_scope.tf
+++ b/tests/syntax_test_scope.tf
@@ -548,7 +548,7 @@
 #      ^^ meta.interpolation.terraform punctuation.section.interpolation.begin.terraform
 #         ^^^ keyword.control.loop.for.terraform
 #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.terraform
-#                  ^^ keyword.operator.iteration.in.terraform
+#                  ^^ keyword.control.loop.in.terraform
 #                     ^^^ meta.interpolation.terraform variable.language.terraform
 #                        ^ meta.interpolation.terraform punctuation.accessor.dot.terraform
 #                         ^^^^^ meta.interpolation.terraform variable.other.member.terraform


### PR DESCRIPTION
See also https://github.com/sublimehq/Packages/pull/4227 for a prior discussion of this.