### PR TITLE
Apply string scopes to resource block identifiers

### DIFF
--- a/Symbols - Indexed.tmPreferences
+++ b/Symbols - Indexed.tmPreferences
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>name</key>
+   <string>Local Symbol List</string>
+   <key>scope</key>
+   <string>
+      entity.name.label
+   </string>
+   <key>settings</key>
+   <dict>
+      <key>showInIndexedSymbolList</key>
+      <integer>1</integer>
+   </dict>
+</dict>
+</plist>

--- a/Symbols - Local.tmPreferences
+++ b/Symbols - Local.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
    <key>name</key>
-   <string>Symbol List</string>
+   <string>Local Symbol List</string>
    <key>scope</key>
    <string>
       meta.block.head.terraform
@@ -12,12 +12,10 @@
    <dict>
       <key>showInSymbolList</key>
       <integer>1</integer>
-      <key>showInIndexedSymbolList</key>
-      <integer>1</integer>
       <key>symbolTransformation</key>
       <string>
-        <!-- Removes trailing whitespace and opening bracket from symbol. -->
-        <![CDATA[/\s*{$//]]>
+         <!-- Removes trailing whitespace from symbol. -->
+         <![CDATA[/\s*$//]]>
       </string>
    </dict>
 </dict>

--- a/Symbols.tmPreferences
+++ b/Symbols.tmPreferences
@@ -6,7 +6,7 @@
    <string>Symbol List</string>
    <key>scope</key>
    <string>
-      meta.type.terraform
+      meta.block.head.terraform
    </string>
    <key>settings</key>
    <dict>

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -57,10 +57,21 @@ variables:
   # https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md#template-expressions
   char_escapes: \\[nrt"\\]|\\u(\h{8}|\h{4})
 
+  # String literals (basically static and single-line strings)
+  # for usage in look-aheads.
+  #
+  # https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#template-expressions
+  string_literal: '"(?:[^"]|{{char_escapes}})*"'
+
+  # A block label
+  #
+  # https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#structural-elements
+  label: (?:{{identifier}}|{{string_literal}})
+
   # Terraform Named Values
   #
   # https://www.terraform.io/docs/language/expressions/references.html
-  named_values: var|local|module|data|path|terraform|each|count|self
+  named_values: (?:var|local|module|data|path|terraform|each|count|self)
 
   # Block types that are known to Terraform.
   #
@@ -73,13 +84,13 @@ variables:
   # resource: https://developer.hashicorp.com/terraform/language/resources/syntax
   # terraform: https://developer.hashicorp.com/terraform/language/terraform#terraform-block-syntax
   # variable: https://developer.hashicorp.com/terraform/language/values/variables
-  terraform_known_blocks: data|ephemeral|locals|module|output|provider|resource|terraform|variable
+  terraform_known_blocks: (?:data|ephemeral|locals|module|output|provider|resource|terraform|variable)
 
   # Terraform built-in type keywords
   #
   # https://www.terraform.io/docs/language/expressions/type-constraints.html#primitive-types
   # https://www.terraform.io/docs/language/expressions/type-constraints.html#dynamic-types-the-quot-any-quot-constraint
-  terraform_type_keywords: any|string|number|bool
+  terraform_type_keywords: (?:any|string|number|bool)
 
   # Built-In Functions
   #
@@ -180,12 +191,12 @@ contexts:
     - include: named-value-references
 
   named-value-references:
-    - match: \b(?:{{named_values}})\b
+    - match: \b{{named_values}}\b
       comment: Special variables available only to Terraform.
       scope: variable.language.terraform
 
   type-keywords:
-    - match: \b(?:{{terraform_type_keywords}})\b
+    - match: \b{{terraform_type_keywords}}\b
       comment: Type keywords known to Terraform.
       scope: storage.type.terraform
 
@@ -265,11 +276,14 @@ contexts:
     - match: \"
       scope: punctuation.definition.string.end.terraform
       pop: 1
+    - include: character-escapes
+    - include: string-interpolation
+    - include: aws-acl
+
+  character-escapes:
     - match: '{{char_escapes}}'
       comment: Character Escapes
       scope: constant.character.escape.terraform
-    - include: string-interpolation
-    - include: aws-acl
 
   aws-acl:
     - match: (?=\barn:aws:)
@@ -676,51 +690,101 @@ contexts:
   #
   # https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md#structural-elements
   blocks:
-    # Special case heuristic for the AWS and friends two-term resources
-    - match: (\b(resource)\s+((")({{identifier}})("))\s+((")({{identifier}})(")))\s*(\{)
-      captures:
-        1: meta.type.terraform
-        2: keyword.declaration.terraform
-        3: meta.string.terraform string.quoted.double.terraform
-        4: punctuation.definition.string.begin.terraform
-        5: support.type.terraform
-        6: punctuation.definition.string.end.terraform
-        7: meta.string.terraform string.quoted.double.terraform
-        8: punctuation.definition.string.begin.terraform
-        9: entity.name.type.terraform
-        10: punctuation.definition.string.end.terraform
-        11: meta.block.terraform punctuation.section.block.begin.terraform
-      push: block-body
-    # Generic
-    - match: (?:\b({{terraform_known_blocks}})\b|({{identifier}}))(?=[-\s\w"]*\{)
-      scope: meta.type.terraform
-      captures:
-        1: keyword.declaration.terraform
-        2: entity.name.type.terraform
-      push: block-name
+    - include: resource-blocks
+    - include: generic-known-blocks
 
-  block-name:
-    - meta_content_scope: meta.type.terraform
+  resource-blocks:
+    # Special case for two-label resources,
+    # where the first denotes the type and the second the name.
+    - match: (?=\bresource(\s+{{label}}){2}\s*\{)
+      push:
+        - body
+        - block-name-label
+        - block-type-label
+        - resource-declaration
+
+  generic-known-blocks:
+    - match: (?=\b({{terraform_known_blocks}}|{{identifier}})(\s+{{label}})*\s*\{)
+      push:
+        - body
+        - generic-block-labels
+        - generic-block-declaration
+
+  resource-declaration:
+    - match: \bresource\b
+      scope: keyword.declaration.terraform
+      pop: 1
+    - include: else-pop
+
+  generic-block-declaration:
+    - match: \b{{terraform_known_blocks}}\b
+      scope: keyword.declaration.terraform
+      pop: 1
+    - match: \b{{identifier}}\b
+      scope: entity.name.type.terraform
+      pop: 1
+    - include: else-pop
+
+  block-type-label:
     - match: \"
       scope: punctuation.definition.string.begin.terraform
-      push: block-name-body
+      set: block-type-label-body
     - match: '{{identifier}}'
-      scope: entity.name.label.terraform
-    - match: \s*(\{)
-      captures:
-        1: meta.block.terraform punctuation.section.block.begin.terraform
-      set: block-body
+      scope: support.type.terraform
+      pop: 1
+    - include: else-pop
 
-  block-name-body:
-    - meta_scope: meta.string.terraform string.quoted.double.terraform
+  block-type-label-body:
+    - meta_scope: meta.string.terraform support.type.terraform
+    - include: character-escapes
     - match: \"
       scope: punctuation.definition.string.end.terraform
       pop: 1
 
-  block-body:
+  block-name-label:
+    - match: \"
+      scope: punctuation.definition.string.begin.terraform
+      set: block-name-label-body
+    - match: '{{identifier}}'
+      scope: entity.name.label.terraform
+      pop: 1
+    - include: else-pop
+
+  block-name-label-body:
+    - meta_scope: meta.string.terraform entity.name.label.terraform
+    - include: character-escapes
+    - match: \"
+      scope: punctuation.definition.string.end.terraform
+      pop: 1
+
+  generic-block-labels:
+    # Labels probably have a meaning, but we don't know which,
+    # so we just scope them as (un-)quoted strings.
+    - match: \"
+      scope: punctuation.definition.string.begin.terraform
+      push: generic-block-label-body
+    - match: '{{identifier}}'
+      scope: string.unquoted.double.terraform
+    - include: else-pop
+
+  generic-block-label-body:
+    - meta_scope: meta.string.terraform string.quoted.double.terraform
+    - include: character-escapes
+    - match: \"
+      scope: punctuation.definition.string.end.terraform
+      pop: 1
+
+  body:
     - meta_content_scope: meta.block.terraform
+    - match: \{
+      scope: punctuation.section.block.begin.terraform
+      set: body-body
+    - include: else-pop
+
+  body-body:
+    - meta_scope: meta.block.body.terraform
     - match: \}
-      scope: meta.block.terraform punctuation.section.block.end.terraform
+      scope: punctuation.section.block.end.terraform
       pop: 1
     - include: main
 

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -724,7 +724,7 @@ contexts:
         - block-declaration
 
   block-declaration:
-    - match: \b{{identifier}}\b
+    - match: '{{identifier}}'
       scope: keyword.declaration.terraform
       pop: 1
     - include: else-pop
@@ -740,10 +740,10 @@ contexts:
 
   block-type-label-body:
     - meta_scope: meta.string.terraform support.type.terraform
-    - include: character-escapes
     - match: \"
       scope: punctuation.definition.string.end.terraform
       pop: 1
+    - include: character-escapes
 
   block-name-label:
     - match: \"
@@ -756,10 +756,10 @@ contexts:
 
   block-name-label-body:
     - meta_scope: meta.string.terraform entity.name.label.terraform
-    - include: character-escapes
     - match: \"
       scope: punctuation.definition.string.end.terraform
       pop: 1
+    - include: character-escapes
 
   generic-block-labels:
     # Labels probably have a meaning, but we don't know which,
@@ -773,10 +773,10 @@ contexts:
 
   generic-block-label-body:
     - meta_scope: meta.string.terraform string.quoted.double.terraform
-    - include: character-escapes
     - match: \"
       scope: punctuation.definition.string.end.terraform
       pop: 1
+    - include: character-escapes
 
   body:
     - meta_content_scope: meta.block.terraform

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -739,7 +739,8 @@ contexts:
     - include: else-pop
 
   block-type-label-body:
-    - meta_scope: meta.string.terraform support.type.terraform
+    - meta_scope: meta.string.terraform
+    - meta_content_scope: support.type.terraform
     - match: \"
       scope: punctuation.definition.string.end.terraform
       pop: 1
@@ -755,7 +756,8 @@ contexts:
     - include: else-pop
 
   block-name-label-body:
-    - meta_scope: meta.string.terraform entity.name.label.terraform
+    - meta_scope: meta.string.terraform
+    - meta_content_scope: entity.name.label.terraform
     - match: \"
       scope: punctuation.definition.string.end.terraform
       pop: 1

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -77,14 +77,17 @@ variables:
   #
   # data: https://developer.hashicorp.com/terraform/language/data-sources
   # ephemeral: https://developer.hashicorp.com/terraform/language/resources/ephemeral
-  # locals: https://developer.hashicorp.com/terraform/language/values/locals
+  # resource: https://developer.hashicorp.com/terraform/language/resources/syntax
+  terraform_typed_and_named_blocks: (?:data|ephemeral|resource)
   # module: https://developer.hashicorp.com/terraform/language/modules/syntax
   # output: https://developer.hashicorp.com/terraform/language/values/outputs
   # provider: https://developer.hashicorp.com/terraform/language/providers/configuration
-  # resource: https://developer.hashicorp.com/terraform/language/resources/syntax
-  # terraform: https://developer.hashicorp.com/terraform/language/terraform#terraform-block-syntax
   # variable: https://developer.hashicorp.com/terraform/language/values/variables
-  terraform_known_blocks: (?:data|ephemeral|locals|module|output|provider|resource|terraform|variable)
+  terraform_named_blocks: (?:module|output|provider|variable)
+  # locals: https://developer.hashicorp.com/terraform/language/values/locals
+  # terraform: https://developer.hashicorp.com/terraform/language/terraform#terraform-block-syntax
+  # (Currently unused because they do not have special behavior implemented.)
+  terraform_other_blocks: (?:locals|terraform)
 
   # Terraform built-in type keywords
   #
@@ -690,38 +693,39 @@ contexts:
   #
   # https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md#structural-elements
   blocks:
-    - include: resource-blocks
-    - include: generic-known-blocks
+    - include: typed-and-named-blocks
+    - include: named-blocks
+    - include: generic-blocks
 
-  resource-blocks:
+  typed-and-named-blocks:
     # Special case for two-label resources,
     # where the first denotes the type and the second the name.
-    - match: (?=\bresource(\s+{{label}}){2}\s*\{)
+    - match: (?=\b{{terraform_typed_and_named_blocks}}(\s+{{label}}){2}\s*\{)
       push:
         - body
         - block-name-label
         - block-type-label
-        - resource-declaration
+        - block-declaration
 
-  generic-known-blocks:
-    - match: (?=\b({{terraform_known_blocks}}|{{identifier}})(\s+{{label}})*\s*\{)
+  named-blocks:
+    # Special case for two-label resources,
+    # where the first denotes the type and the second the name.
+    - match: (?=\b{{terraform_named_blocks}}\s+{{label}}\s*\{)
+      push:
+        - body
+        - block-name-label
+        - block-declaration
+
+  generic-blocks:
+    - match: (?=\b({{identifier}})(\s+{{label}})*\s*\{)
       push:
         - body
         - generic-block-labels
-        - generic-block-declaration
+        - block-declaration
 
-  resource-declaration:
-    - match: \bresource\b
-      scope: keyword.declaration.terraform
-      pop: 1
-    - include: else-pop
-
-  generic-block-declaration:
-    - match: \b{{terraform_known_blocks}}\b
-      scope: keyword.declaration.terraform
-      pop: 1
+  block-declaration:
     - match: \b{{identifier}}\b
-      scope: entity.name.type.terraform
+      scope: keyword.declaration.terraform
       pop: 1
     - include: else-pop
 

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -676,17 +676,19 @@ contexts:
   # https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md#structural-elements
   block:
     # Special case heuristic for the AWS and friends two-term resources
-    - match: (\b(resource)\s+(")({{identifier}})(")\s+(")({{identifier}})("))\s*(\{)
+    - match: (\b(resource)\s+((")({{identifier}})("))\s+((")({{identifier}})(")))\s*(\{)
       captures:
         1: meta.type.terraform
         2: keyword.declaration.terraform
-        3: punctuation.definition.begin.terraform
-        4: support.type.terraform
-        5: punctuation.definition.end.terraform
-        6: punctuation.definition.begin.terraform
-        7: entity.name.type.terraform
-        8: punctuation.definition.end.terraform
-        9: meta.block.terraform punctuation.section.block.begin.terraform
+        3: meta.string.terraform string.quoted.double.terraform
+        4: punctuation.definition.string.begin.terraform
+        5: support.type.terraform
+        6: punctuation.definition.string.end.terraform
+        7: meta.string.terraform string.quoted.double.terraform
+        8: punctuation.definition.string.begin.terraform
+        9: entity.name.type.terraform
+        10: punctuation.definition.string.end.terraform
+        11: meta.block.terraform punctuation.section.block.begin.terraform
       push: block-body
     # Generic
     - match: (?:\b({{terraform_known_blocks}})\b|({{identifier}}))(?=[-\s\w"]*\{)

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -4,7 +4,8 @@
 # https://www.terraform.io/docs/language/index.html
 #
 # As well as the HCL Native Syntax Spec:
-# https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md
+# https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md
+# (previously https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md)
 #
 # For documentation on the .subline-syntax format:
 # https://www.sublimetext.com/docs/syntax.html

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -127,7 +127,7 @@ contexts:
     - include: comments
     - include: attribute-definition
     - include: imports
-    - include: block
+    - include: blocks
     - include: expressions
 
   comments:
@@ -675,7 +675,7 @@ contexts:
   # Blocks: Identifier (StringLit|Identifier)* "{" Newline Body "}" Newline;
   #
   # https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md#structural-elements
-  block:
+  blocks:
     # Special case heuristic for the AWS and friends two-term resources
     - match: (\b(resource)\s+((")({{identifier}})("))\s+((")({{identifier}})(")))\s*(\{)
       captures:

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -779,7 +779,7 @@ contexts:
     - include: character-escapes
 
   body:
-    - meta_content_scope: meta.block.terraform
+    - meta_content_scope: meta.block.head.terraform
     - match: \{
       scope: punctuation.section.block.begin.terraform
       set: body-body

--- a/tests/syntax_test_scope.tf
+++ b/tests/syntax_test_scope.tf
@@ -2957,7 +2957,7 @@
 ////
 
     thing  {}
-#   ^^^^^^^ meta.block.terraform
+#   ^^^^^^^ meta.block.head.terraform
 #   ^^^^^ keyword.declaration.terraform
 #          ^^ meta.block.body.terraform
 #          ^ punctuation.section.block.begin.terraform
@@ -2968,7 +2968,7 @@
 /////
 
     thing "label1"   "label2\"" {}
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^ keyword.declaration.terraform
 #         ^^^^^^^^ meta.string.terraform string.quoted.double.terraform
 #         ^ punctuation.definition.string.begin.terraform
@@ -2986,7 +2986,7 @@
 /////
 
     thing thing1 thing2 thing3 {}
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^ keyword.declaration.terraform
 #         ^^^^^^ string.unquoted.double.terraform
 #                ^^^^^^ string.unquoted.double.terraform
@@ -3000,7 +3000,7 @@
 /////
 
     resource "aws_security_group" "example" {
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^^^ keyword.declaration.terraform
 #            ^^^^^^^^^^^^^^^^^^^^ meta.string.terraform support.type.terraform
 #            ^ punctuation.definition.string.begin.terraform
@@ -3019,7 +3019,8 @@
 #                    ^ punctuation.definition.string.end.terraform
 
       dynamic "ingress" {
-#     ^^^^^^^^^^^^^^^^^^ meta.block.body.terraform meta.block.terraform - meta.block meta.block meta.block
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.body.terraform - meta.block meta.block meta.block
+#     ^^^^^^^^^^^^^^^^^^ meta.block.body.terraform meta.block.head.terraform
 #     ^^^^^^^ keyword.declaration.terraform
 #             ^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
 #             ^ punctuation.definition.string.begin.terraform
@@ -3033,7 +3034,7 @@
 #                     ^ punctuation.accessor.dot.terraform
 #                      ^^^^^^^^^^^^^ variable.other.member.terraform
         content {
-#       ^^^^^^^ meta.block.body.terraform meta.block.body.terraform meta.block.terraform
+#       ^^^^^^^ meta.block.body.terraform meta.block.body.terraform meta.block.head.terraform
 #              ^ meta.block.body.terraform meta.block.body.terraform - meta.type
 #               ^^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform - meta.type
 #       ^^^^^^^ keyword.declaration.terraform
@@ -3068,7 +3069,7 @@
 /////
 
     thing label1 {
-#   ^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^ keyword.declaration.terraform
 #         ^^^^^^ string.unquoted.double.terraform
 #                ^ meta.block.body.terraform punctuation.section.block.begin.terraform
@@ -3163,7 +3164,7 @@
 /////////////////////////////////////////////////////////////////////
 
     resource "type" "name" {}
-#   ^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^^^ keyword.declaration.terraform
 #            ^^^^^^ meta.string.terraform support.type.terraform
 #            ^ punctuation.definition.string.begin.terraform
@@ -3176,7 +3177,7 @@
 #                           ^ punctuation.section.block.end.terraform
 
     ephemeral "type" "name" {}
-#   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^^^^ keyword.declaration.terraform
 #             ^^^^^^ meta.string.terraform support.type.terraform
 #             ^ punctuation.definition.string.begin.terraform
@@ -3189,7 +3190,7 @@
 #                            ^ punctuation.section.block.end.terraform
 
     data "type" name {}
-#   ^^^^^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^ keyword.declaration.terraform
 #        ^^^^^^ meta.string.terraform support.type.terraform
 #        ^ punctuation.definition.string.begin.terraform
@@ -3200,7 +3201,7 @@
 #                     ^ punctuation.section.block.end.terraform
 
     provider "name" {}
-#   ^^^^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^^^ keyword.declaration.terraform
 #            ^^^^^^ meta.string.terraform entity.name.label.terraform
 #            ^ punctuation.definition.string.begin.terraform
@@ -3210,7 +3211,7 @@
 #                    ^ punctuation.section.block.end.terraform
 
     module name {}
-#   ^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^ keyword.declaration.terraform
 #          ^^^^ entity.name.label.terraform
 #               ^^ meta.block.body.terraform
@@ -3218,7 +3219,7 @@
 #                ^ punctuation.section.block.end.terraform
 
     variable "name" {}
-#   ^^^^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^^^ keyword.declaration.terraform
 #            ^^^^^^ meta.string.terraform entity.name.label.terraform
 #            ^ punctuation.definition.string.begin.terraform
@@ -3228,7 +3229,7 @@
 #                    ^ punctuation.section.block.end.terraform
 
     output "name"{}
-#   ^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^ keyword.declaration.terraform
 #          ^^^^^^ meta.string.terraform entity.name.label.terraform
 #          ^ punctuation.definition.string.begin.terraform
@@ -3238,14 +3239,14 @@
 #                 ^ punctuation.section.block.end.terraform
 
     locals {}
-#   ^^^^^^^ meta.block.terraform
+#   ^^^^^^^ meta.block.head.terraform
 #   ^^^^^^ keyword.declaration.terraform
 #          ^^ meta.block.body.terraform
 #          ^ punctuation.section.block.begin.terraform
 #           ^ punctuation.section.block.end.terraform
 
     terraform {}
-#   ^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^^^^ keyword.declaration.terraform
 #             ^^ meta.block.body.terraform
 #             ^ punctuation.section.block.begin.terraform

--- a/tests/syntax_test_scope.tf
+++ b/tests/syntax_test_scope.tf
@@ -2957,9 +2957,9 @@
 ////
 
     thing  {}
-#   ^^^^^ meta.type.terraform entity.name.type.terraform
-#        ^^ - meta.type - meta.block
-#          ^^ meta.block.terraform - meta.type
+#   ^^^^^^^ meta.block.terraform
+#   ^^^^^ entity.name.type.terraform
+#          ^^ meta.block.body.terraform
 #          ^ punctuation.section.block.begin.terraform
 #           ^ punctuation.section.block.end.terraform
 
@@ -2967,26 +2967,31 @@
 // Inline block with string labels.
 /////
 
-    thing "label1"   "label2" {}
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.terraform
+    thing "label1"   "label2\"" {}
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform
 #   ^^^^^ entity.name.type.terraform
 #         ^^^^^^^^ meta.string.terraform string.quoted.double.terraform
-#                    ^^^^^^^^ meta.string.terraform string.quoted.double.terraform
-#                            ^ - meta.type - meta.block
-#                             ^^ meta.block.terraform - meta.type
-#                               ^ - meta
+#         ^ punctuation.definition.string.begin.terraform
+#                ^ punctuation.definition.string.end.terraform
+#                    ^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#                    ^ punctuation.definition.string.begin.terraform
+#                           ^^ constant.character.escape.terraform
+#                             ^ punctuation.definition.string.end.terraform
+#                               ^^ meta.block.body.terraform
+#                               ^ punctuation.section.block.begin.terraform
+#                                ^ punctuation.section.block.end.terraform
 
 /////
 // Inline block with identifier labels.
 /////
 
     thing thing1 thing2 thing3 {}
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.terraform
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform
 #   ^^^^^ entity.name.type.terraform
-#         ^^^^^^ entity.name.label.terraform
-#                ^^^^^^ entity.name.label.terraform
-#                       ^^^^^^ entity.name.label.terraform
-#                              ^^ meta.block.terraform - meta.type
+#         ^^^^^^ string.unquoted.double.terraform
+#                ^^^^^^ string.unquoted.double.terraform
+#                       ^^^^^^ string.unquoted.double.terraform
+#                              ^^ meta.block.body.terraform
 #                              ^ punctuation.section.block.begin.terraform
 #                               ^ punctuation.section.block.end.terraform
 
@@ -2995,20 +3000,18 @@
 /////
 
     resource "aws_security_group" "example" {
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.terraform
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform
 #   ^^^^^^^^ keyword.declaration.terraform
-#            ^^^^^^^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#            ^^^^^^^^^^^^^^^^^^^^ meta.string.terraform support.type.terraform
 #            ^ punctuation.definition.string.begin.terraform
-#             ^^^^^^^^^^^^^^^^^^ support.type.terraform
 #                               ^ punctuation.definition.string.end.terraform
-#                                 ^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#                                 ^^^^^^^^^ meta.string.terraform entity.name.label.terraform
 #                                 ^ punctuation.definition.string.begin.terraform
-#                                  ^^^^^^^ entity.name.type.terraform
 #                                         ^ punctuation.definition.string.end.terraform
-#                                           ^ meta.block.terraform punctuation.section.block.begin.terraform
+#                                           ^ meta.block.body.terraform punctuation.section.block.begin.terraform
 
       name = "example"
-#     ^^^^^^^^^^^^^^^^ meta.block.terraform
+#     ^^^^^^^^^^^^^^^^ meta.block.body.terraform
 #     ^^^^ variable.declaration.terraform variable.other.readwrite.terraform
 #          ^ keyword.operator.assignment.terraform
 #            ^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
@@ -3016,13 +3019,13 @@
 #                    ^ punctuation.definition.string.end.terraform
 
       dynamic "ingress" {
-#     ^^^^^^^^^^^^^^^^^ meta.block.terraform meta.type.terraform - meta.block meta.block
-#                      ^ meta.block.terraform - meta.type - meta.block meta.block
-#                       ^^ meta.block.terraform meta.block.terraform
-#     ^^^^^^^ meta.type.terraform entity.name.type.terraform
-#             ^ meta.type.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#              ^^^^^^^^ meta.type.terraform string.quoted.double.terraform
-#                       ^ punctuation.section.block.begin.terraform
+#     ^^^^^^^^^^^^^^^^^^ meta.block.body.terraform meta.block.terraform - meta.block meta.block meta.block
+#     ^^^^^^^ entity.name.type.terraform
+#             ^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#             ^ punctuation.definition.string.begin.terraform
+#                     ^ punctuation.definition.string.end.terraform
+#                       ^ meta.block.body.terraform meta.block.body.terraform punctuation.section.block.begin.terraform
+
         for_each = var.service_ports
 #       ^^^^^^^^ variable.declaration.terraform keyword.control.loop.for.terraform
 #                ^ keyword.operator.assignment.terraform
@@ -3030,34 +3033,34 @@
 #                     ^ punctuation.accessor.dot.terraform
 #                      ^^^^^^^^^^^^^ variable.other.member.terraform
         content {
-#       ^^^^^^^ meta.block.terraform meta.block.terraform meta.type.terraform
-#              ^ meta.block.terraform meta.block.terraform - meta.type
-#               ^^ meta.block.terraform meta.block.terraform meta.block.terraform - meta.type
+#       ^^^^^^^ meta.block.body.terraform meta.block.body.terraform meta.block.terraform
+#              ^ meta.block.body.terraform meta.block.body.terraform - meta.type
+#               ^^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform - meta.type
 #       ^^^^^^^ entity.name.type.terraform
 #               ^ punctuation.section.block.begin.terraform
           from_port = ingress.value
-#         ^^^^^^^^^ meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#                   ^ meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.assignment.terraform
-#                            ^ meta.block.terraform meta.block.terraform meta.block.terraform punctuation.accessor.dot.terraform
-#                             ^^^^^ meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
+#         ^^^^^^^^^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#                   ^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform keyword.operator.assignment.terraform
+#                            ^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform punctuation.accessor.dot.terraform
+#                             ^^^^^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform variable.other.member.terraform
           to_port   = ingress.value
-#         ^^^^^^^ meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#                   ^ meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.assignment.terraform
-#                            ^ meta.block.terraform meta.block.terraform meta.block.terraform punctuation.accessor.dot.terraform
+#         ^^^^^^^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#                   ^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform keyword.operator.assignment.terraform
+#                            ^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform punctuation.accessor.dot.terraform
           protocol  = "tcp" + "IP"
-#         ^^^^^^^^ meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#                   ^ meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.assignment.terraform
-#                     ^ meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                      ^^^^ meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                           ^ meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.arithmetic.terraform
-#                             ^ meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                              ^^^ meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
+#         ^^^^^^^^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#                   ^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform keyword.operator.assignment.terraform
+#                     ^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                      ^^^^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform string.quoted.double.terraform
+#                           ^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform keyword.operator.arithmetic.terraform
+#                             ^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                              ^^^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform string.quoted.double.terraform
         }
-#       ^ meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+#       ^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform punctuation.section.block.end.terraform
       }
-#     ^ meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+#     ^ meta.block.body.terraform meta.block.body.terraform punctuation.section.block.end.terraform
     }
-#   ^ meta.block.terraform punctuation.section.block.end.terraform
+#   ^ meta.block.body.terraform punctuation.section.block.end.terraform
 #    ^ - meta
 
 /////
@@ -3065,14 +3068,13 @@
 /////
 
     thing label1 {
-#   ^^^^^^^^^^^^ meta.type.terraform
-#               ^ - meta.block - meta.type
-#                ^^ meta.block.terraform - meta.type
+#   ^^^^^^^^^^^^^ meta.block.terraform
 #   ^^^^^ entity.name.type.terraform
-#         ^^^^^^ entity.name.label.terraform
-#                ^ punctuation.section.block.begin.terraform
+#         ^^^^^^ string.unquoted.double.terraform
+#                ^ meta.block.body.terraform punctuation.section.block.begin.terraform
+
       func = function(param1)
-#    ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.body.terraform
 #     ^^^^ variable.declaration.terraform variable.other.readwrite.terraform
 #          ^ keyword.operator.assignment.terraform
 #            ^^^^^^^^ meta.function-call.identifier.terraform variable.function.terraform
@@ -3080,27 +3082,27 @@
 #                     ^^^^^^ meta.function-call.arguments.terraform
 #                           ^ meta.function-call.arguments.terraform punctuation.section.parens.end.terraform
       obj = {
-#    ^^^^^^^ meta.block.terraform - meta.braces
-#           ^^ meta.block.terraform meta.braces.terraform
+#    ^^^^^^^ meta.block.body.terraform - meta.braces
+#           ^^ meta.block.body.terraform meta.braces.terraform
 #     ^^^ variable.declaration.terraform variable.other.readwrite.terraform
 #         ^ keyword.operator.assignment.terraform
         key = "value"
-#      ^^^^^^^^^^^^^^^ meta.block.terraform meta.braces.terraform
+#      ^^^^^^^^^^^^^^^ meta.block.body.terraform meta.braces.terraform
 #       ^^^ meta.mapping.key.terraform string.unquoted.terraform
 #           ^ keyword.operator.assignment.terraform
 #             ^^^^^^^ meta.string.terraform string.quoted.double.terraform
       }
-#     ^ meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
+#     ^ meta.block.body.terraform meta.braces.terraform punctuation.section.braces.end.terraform
       tuple = [1, 2]
-#     ^^^^^ meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#           ^ meta.block.terraform keyword.operator.assignment.terraform
-#             ^ meta.block.terraform punctuation.section.brackets.begin.terraform
-#              ^ meta.block.terraform meta.number.integer.decimal.terraform constant.numeric.value.terraform
-#               ^ meta.block.terraform punctuation.separator.terraform
-#                 ^ meta.block.terraform meta.number.integer.decimal.terraform constant.numeric.value.terraform
-#                  ^ meta.block.terraform punctuation.section.brackets.end.terraform
+#     ^^^^^ meta.block.body.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#           ^ meta.block.body.terraform keyword.operator.assignment.terraform
+#             ^ meta.block.body.terraform punctuation.section.brackets.begin.terraform
+#              ^ meta.block.body.terraform meta.number.integer.decimal.terraform constant.numeric.value.terraform
+#               ^ meta.block.body.terraform punctuation.separator.terraform
+#                 ^ meta.block.body.terraform meta.number.integer.decimal.terraform constant.numeric.value.terraform
+#                  ^ meta.block.body.terraform punctuation.section.brackets.end.terraform
     }
-#   ^ meta.block.terraform punctuation.section.block.end.terraform
+#   ^ meta.block.body.terraform punctuation.section.block.end.terraform
 #    ^ - meta - block
 
 /////////////////////////////////////////////////////////////////////
@@ -3161,52 +3163,60 @@
 /////////////////////////////////////////////////////////////////////
 
     resource {}
-#   ^^^^^^^^ meta.type.terraform keyword.declaration.terraform
-#           ^ - meta.block - meta.type
-#            ^ meta.block.terraform punctuation.section.block.begin.terraform - meta.type
-#             ^ meta.block.terraform punctuation.section.block.end.terraform - meta.type
+#   ^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^ keyword.declaration.terraform
+#            ^^ meta.block.body.terraform
+#            ^ punctuation.section.block.begin.terraform
+#             ^ punctuation.section.block.end.terraform
 
     provider {}
-#   ^^^^^^^^ meta.type.terraform keyword.declaration.terraform
-#           ^ - meta.block - meta.type
-#            ^ meta.block.terraform punctuation.section.block.begin.terraform - meta.type
-#             ^ meta.block.terraform punctuation.section.block.end.terraform - meta.type
+#   ^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^ keyword.declaration.terraform
+#            ^^ meta.block.body.terraform
+#            ^ punctuation.section.block.begin.terraform
+#             ^ punctuation.section.block.end.terraform
 
     variable {}
-#   ^^^^^^^^ meta.type.terraform keyword.declaration.terraform
-#           ^ - meta.block - meta.type
-#            ^ meta.block.terraform punctuation.section.block.begin.terraform - meta.type
-#             ^ meta.block.terraform punctuation.section.block.end.terraform - meta.type
+#   ^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^ keyword.declaration.terraform
+#            ^^ meta.block.body.terraform
+#            ^ punctuation.section.block.begin.terraform
+#             ^ punctuation.section.block.end.terraform
 
     output {}
-#   ^^^^^^ meta.type.terraform keyword.declaration.terraform
-#         ^ - meta.block - meta.type
-#          ^ meta.block.terraform punctuation.section.block.begin.terraform - meta.type
-#           ^ meta.block.terraform punctuation.section.block.end.terraform - meta.type
+#   ^^^^^^^ meta.block.terraform
+#   ^^^^^^ keyword.declaration.terraform
+#          ^^ meta.block.body.terraform
+#          ^ punctuation.section.block.begin.terraform
+#           ^ punctuation.section.block.end.terraform
 
     locals {}
-#   ^^^^^^ meta.type.terraform keyword.declaration.terraform
-#         ^ - meta.block - meta.type
-#          ^ meta.block.terraform punctuation.section.block.begin.terraform - meta.type
-#           ^ meta.block.terraform punctuation.section.block.end.terraform - meta.type
+#   ^^^^^^^ meta.block.terraform
+#   ^^^^^^ keyword.declaration.terraform
+#          ^^ meta.block.body.terraform
+#          ^ punctuation.section.block.begin.terraform
+#           ^ punctuation.section.block.end.terraform
 
     module {}
-#   ^^^^^^ meta.type.terraform keyword.declaration.terraform
-#         ^ - meta.block - meta.type
-#          ^ meta.block.terraform punctuation.section.block.begin.terraform - meta.type
-#           ^ meta.block.terraform punctuation.section.block.end.terraform - meta.type
+#   ^^^^^^^ meta.block.terraform
+#   ^^^^^^ keyword.declaration.terraform
+#          ^^ meta.block.body.terraform
+#          ^ punctuation.section.block.begin.terraform
+#           ^ punctuation.section.block.end.terraform
 
     data {}
-#   ^^^^ meta.type.terraform keyword.declaration.terraform
-#       ^ - meta.block - meta.type
-#        ^ meta.block.terraform punctuation.section.block.begin.terraform - meta.type
-#         ^ meta.block.terraform punctuation.section.block.end.terraform - meta.type
+#   ^^^^^ meta.block.terraform
+#   ^^^^ keyword.declaration.terraform
+#        ^^ meta.block.body.terraform
+#        ^ punctuation.section.block.begin.terraform
+#         ^ punctuation.section.block.end.terraform
 
     terraform {}
-#   ^^^^^^^^^ meta.type.terraform keyword.declaration.terraform
-#            ^ - meta.block - meta.type
-#             ^ meta.block.terraform punctuation.section.block.begin.terraform - meta.type
-#              ^ meta.block.terraform punctuation.section.block.end.terraform - meta.type
+#   ^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^ keyword.declaration.terraform
+#             ^^ meta.block.body.terraform
+#             ^ punctuation.section.block.begin.terraform
+#              ^ punctuation.section.block.end.terraform
 
 /////////////////////////////////////////////////////////////////////
 // TERRAFORM TYPE KEYWORDS
@@ -3313,7 +3323,7 @@ resource "aws_iam_role_policy" "attach-inline-policy-1" {
     role = aws_iam_role.execution-role.name
 
     res_arn = "arn:aws:lambda:*:*:function:${var.environment}-xxx"
-#             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform meta.string.terraform
+#             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.body.terraform meta.string.terraform
 #             ^ string.quoted.double.terraform punctuation.definition.string.begin.terraform - variable
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ variable.language.acl.terraform
 #                                          ^^ punctuation.section.interpolation.begin.terraform
@@ -3326,14 +3336,14 @@ resource "aws_iam_role_policy" "attach-inline-policy-1" {
 
     policy = jsonencode({
         Version = "2012-10-17"
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform meta.function-call.arguments.terraform meta.braces.terraform
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.body.terraform meta.function-call.arguments.terraform meta.braces.terraform
 #       ^^^^^^^ meta.mapping.key.terraform string.unquoted.terraform
 #               ^ keyword.operator.assignment.terraform
 #                 ^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
 #                 ^ punctuation.definition.string.begin.terraform
 #                            ^ punctuation.definition.string.end.terraform
         "Statement": [
-#^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform meta.function-call.arguments.terraform
+#^^^^^^^^^^^^^^^^^^^^^ meta.block.body.terraform meta.function-call.arguments.terraform
 #^^^^^^^ meta.braces.terraform
 #       ^^^^^^^^^^^ meta.mapping.key.json string.quoted.double.json
 #       ^ punctuation.definition.string.begin.json
@@ -3347,7 +3357,7 @@ resource "aws_iam_role_policy" "attach-inline-policy-1" {
                     "lambda:InvokeAsync"
                 ],
                 "Resource": "arn:aws:lambda:*:*:function:${var.environment}-xxx",
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform meta.function-call.arguments.terraform meta.mapping.value.json meta.sequence.json
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.body.terraform meta.function-call.arguments.terraform meta.mapping.value.json meta.sequence.json
 #^^^^^^^^^^^^^^^ meta.mapping.json
 #               ^^^^^^^^^^ meta.mapping.key.json string.quoted.double.json
 #                         ^^ meta.mapping.json

--- a/tests/syntax_test_scope.tf
+++ b/tests/syntax_test_scope.tf
@@ -2958,7 +2958,7 @@
 
     thing  {}
 #   ^^^^^^^ meta.block.terraform
-#   ^^^^^ entity.name.type.terraform
+#   ^^^^^ keyword.declaration.terraform
 #          ^^ meta.block.body.terraform
 #          ^ punctuation.section.block.begin.terraform
 #           ^ punctuation.section.block.end.terraform
@@ -2969,7 +2969,7 @@
 
     thing "label1"   "label2\"" {}
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform
-#   ^^^^^ entity.name.type.terraform
+#   ^^^^^ keyword.declaration.terraform
 #         ^^^^^^^^ meta.string.terraform string.quoted.double.terraform
 #         ^ punctuation.definition.string.begin.terraform
 #                ^ punctuation.definition.string.end.terraform
@@ -2987,7 +2987,7 @@
 
     thing thing1 thing2 thing3 {}
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform
-#   ^^^^^ entity.name.type.terraform
+#   ^^^^^ keyword.declaration.terraform
 #         ^^^^^^ string.unquoted.double.terraform
 #                ^^^^^^ string.unquoted.double.terraform
 #                       ^^^^^^ string.unquoted.double.terraform
@@ -3020,7 +3020,7 @@
 
       dynamic "ingress" {
 #     ^^^^^^^^^^^^^^^^^^ meta.block.body.terraform meta.block.terraform - meta.block meta.block meta.block
-#     ^^^^^^^ entity.name.type.terraform
+#     ^^^^^^^ keyword.declaration.terraform
 #             ^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
 #             ^ punctuation.definition.string.begin.terraform
 #                     ^ punctuation.definition.string.end.terraform
@@ -3036,7 +3036,7 @@
 #       ^^^^^^^ meta.block.body.terraform meta.block.body.terraform meta.block.terraform
 #              ^ meta.block.body.terraform meta.block.body.terraform - meta.type
 #               ^^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform - meta.type
-#       ^^^^^^^ entity.name.type.terraform
+#       ^^^^^^^ keyword.declaration.terraform
 #               ^ punctuation.section.block.begin.terraform
           from_port = ingress.value
 #         ^^^^^^^^^ meta.block.body.terraform meta.block.body.terraform meta.block.body.terraform variable.declaration.terraform variable.other.readwrite.terraform
@@ -3069,7 +3069,7 @@
 
     thing label1 {
 #   ^^^^^^^^^^^^^ meta.block.terraform
-#   ^^^^^ entity.name.type.terraform
+#   ^^^^^ keyword.declaration.terraform
 #         ^^^^^^ string.unquoted.double.terraform
 #                ^ meta.block.body.terraform punctuation.section.block.begin.terraform
 
@@ -3162,33 +3162,80 @@
 // TERRAFORM TOP-LEVEL BLOCK TYPES
 /////////////////////////////////////////////////////////////////////
 
-    resource {}
-#   ^^^^^^^^^ meta.block.terraform
+    resource "type" "name" {}
+#   ^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform
 #   ^^^^^^^^ keyword.declaration.terraform
-#            ^^ meta.block.body.terraform
-#            ^ punctuation.section.block.begin.terraform
-#             ^ punctuation.section.block.end.terraform
+#            ^^^^^^ meta.string.terraform support.type.terraform
+#            ^ punctuation.definition.string.begin.terraform
+#                 ^ punctuation.definition.string.end.terraform
+#                   ^^^^^^ meta.string.terraform entity.name.label.terraform
+#                   ^ punctuation.definition.string.begin.terraform
+#                        ^ punctuation.definition.string.end.terraform
+#                          ^^ meta.block.body.terraform
+#                          ^ punctuation.section.block.begin.terraform
+#                           ^ punctuation.section.block.end.terraform
 
-    provider {}
-#   ^^^^^^^^^ meta.block.terraform
+    ephemeral "type" "name" {}
+#   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^^ keyword.declaration.terraform
+#             ^^^^^^ meta.string.terraform support.type.terraform
+#             ^ punctuation.definition.string.begin.terraform
+#                  ^ punctuation.definition.string.end.terraform
+#                    ^^^^^^ meta.string.terraform entity.name.label.terraform
+#                    ^ punctuation.definition.string.begin.terraform
+#                         ^ punctuation.definition.string.end.terraform
+#                           ^^ meta.block.body.terraform
+#                           ^ punctuation.section.block.begin.terraform
+#                            ^ punctuation.section.block.end.terraform
+
+    data "type" name {}
+#   ^^^^^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^ keyword.declaration.terraform
+#        ^^^^^^ meta.string.terraform support.type.terraform
+#        ^ punctuation.definition.string.begin.terraform
+#             ^ punctuation.definition.string.end.terraform
+#               ^^^^ entity.name.label.terraform
+#                    ^^ meta.block.body.terraform
+#                    ^ punctuation.section.block.begin.terraform
+#                     ^ punctuation.section.block.end.terraform
+
+    provider "name" {}
+#   ^^^^^^^^^^^^^^^^ meta.block.terraform
 #   ^^^^^^^^ keyword.declaration.terraform
-#            ^^ meta.block.body.terraform
-#            ^ punctuation.section.block.begin.terraform
-#             ^ punctuation.section.block.end.terraform
+#            ^^^^^^ meta.string.terraform entity.name.label.terraform
+#            ^ punctuation.definition.string.begin.terraform
+#                 ^ punctuation.definition.string.end.terraform
+#                   ^^ meta.block.body.terraform
+#                   ^ punctuation.section.block.begin.terraform
+#                    ^ punctuation.section.block.end.terraform
 
-    variable {}
-#   ^^^^^^^^^ meta.block.terraform
-#   ^^^^^^^^ keyword.declaration.terraform
-#            ^^ meta.block.body.terraform
-#            ^ punctuation.section.block.begin.terraform
-#             ^ punctuation.section.block.end.terraform
-
-    output {}
-#   ^^^^^^^ meta.block.terraform
+    module name {}
+#   ^^^^^^^^^^^^ meta.block.terraform
 #   ^^^^^^ keyword.declaration.terraform
-#          ^^ meta.block.body.terraform
-#          ^ punctuation.section.block.begin.terraform
-#           ^ punctuation.section.block.end.terraform
+#          ^^^^ entity.name.label.terraform
+#               ^^ meta.block.body.terraform
+#               ^ punctuation.section.block.begin.terraform
+#                ^ punctuation.section.block.end.terraform
+
+    variable "name" {}
+#   ^^^^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^^^ keyword.declaration.terraform
+#            ^^^^^^ meta.string.terraform entity.name.label.terraform
+#            ^ punctuation.definition.string.begin.terraform
+#                 ^ punctuation.definition.string.end.terraform
+#                   ^^ meta.block.body.terraform
+#                   ^ punctuation.section.block.begin.terraform
+#                    ^ punctuation.section.block.end.terraform
+
+    output "name"{}
+#   ^^^^^^^^^^^^^ meta.block.terraform
+#   ^^^^^^ keyword.declaration.terraform
+#          ^^^^^^ meta.string.terraform entity.name.label.terraform
+#          ^ punctuation.definition.string.begin.terraform
+#               ^ punctuation.definition.string.end.terraform
+#                ^^ meta.block.body.terraform
+#                ^ punctuation.section.block.begin.terraform
+#                 ^ punctuation.section.block.end.terraform
 
     locals {}
 #   ^^^^^^^ meta.block.terraform
@@ -3196,20 +3243,6 @@
 #          ^^ meta.block.body.terraform
 #          ^ punctuation.section.block.begin.terraform
 #           ^ punctuation.section.block.end.terraform
-
-    module {}
-#   ^^^^^^^ meta.block.terraform
-#   ^^^^^^ keyword.declaration.terraform
-#          ^^ meta.block.body.terraform
-#          ^ punctuation.section.block.begin.terraform
-#           ^ punctuation.section.block.end.terraform
-
-    data {}
-#   ^^^^^ meta.block.terraform
-#   ^^^^ keyword.declaration.terraform
-#        ^^ meta.block.body.terraform
-#        ^ punctuation.section.block.begin.terraform
-#         ^ punctuation.section.block.end.terraform
 
     terraform {}
 #   ^^^^^^^^^^ meta.block.terraform

--- a/tests/syntax_test_scope.tf
+++ b/tests/syntax_test_scope.tf
@@ -3002,11 +3002,13 @@
     resource "aws_security_group" "example" {
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^^^ keyword.declaration.terraform
-#            ^^^^^^^^^^^^^^^^^^^^ meta.string.terraform support.type.terraform
+#            ^^^^^^^^^^^^^^^^^^^^ meta.string.terraform
 #            ^ punctuation.definition.string.begin.terraform
+#             ^^^^^^^^^^^^^^^^^^ support.type.terraform
 #                               ^ punctuation.definition.string.end.terraform
-#                                 ^^^^^^^^^ meta.string.terraform entity.name.label.terraform
+#                                 ^^^^^^^^^ meta.string.terraform
 #                                 ^ punctuation.definition.string.begin.terraform
+#                                  ^^^^^^^ entity.name.label.terraform
 #                                         ^ punctuation.definition.string.end.terraform
 #                                           ^ meta.block.body.terraform punctuation.section.block.begin.terraform
 
@@ -3166,11 +3168,13 @@
     resource "type" "name" {}
 #   ^^^^^^^^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^^^ keyword.declaration.terraform
-#            ^^^^^^ meta.string.terraform support.type.terraform
+#            ^^^^^^ meta.string.terraform
 #            ^ punctuation.definition.string.begin.terraform
+#             ^^^^ support.type.terraform
 #                 ^ punctuation.definition.string.end.terraform
-#                   ^^^^^^ meta.string.terraform entity.name.label.terraform
+#                   ^^^^^^ meta.string.terraform
 #                   ^ punctuation.definition.string.begin.terraform
+#                    ^^^^ entity.name.label.terraform
 #                        ^ punctuation.definition.string.end.terraform
 #                          ^^ meta.block.body.terraform
 #                          ^ punctuation.section.block.begin.terraform
@@ -3179,11 +3183,13 @@
     ephemeral "type" "name" {}
 #   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^^^^ keyword.declaration.terraform
-#             ^^^^^^ meta.string.terraform support.type.terraform
+#             ^^^^^^ meta.string.terraform
 #             ^ punctuation.definition.string.begin.terraform
+#              ^^^^ support.type.terraform
 #                  ^ punctuation.definition.string.end.terraform
-#                    ^^^^^^ meta.string.terraform entity.name.label.terraform
+#                    ^^^^^^ meta.string.terraform
 #                    ^ punctuation.definition.string.begin.terraform
+#                     ^^^^ entity.name.label.terraform
 #                         ^ punctuation.definition.string.end.terraform
 #                           ^^ meta.block.body.terraform
 #                           ^ punctuation.section.block.begin.terraform
@@ -3192,8 +3198,9 @@
     data "type" name {}
 #   ^^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^ keyword.declaration.terraform
-#        ^^^^^^ meta.string.terraform support.type.terraform
+#        ^^^^^^ meta.string.terraform
 #        ^ punctuation.definition.string.begin.terraform
+#         ^^^^ support.type.terraform
 #             ^ punctuation.definition.string.end.terraform
 #               ^^^^ entity.name.label.terraform
 #                    ^^ meta.block.body.terraform
@@ -3203,8 +3210,9 @@
     provider "name" {}
 #   ^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^^^ keyword.declaration.terraform
-#            ^^^^^^ meta.string.terraform entity.name.label.terraform
+#            ^^^^^^ meta.string.terraform
 #            ^ punctuation.definition.string.begin.terraform
+#             ^^^^ entity.name.label.terraform
 #                 ^ punctuation.definition.string.end.terraform
 #                   ^^ meta.block.body.terraform
 #                   ^ punctuation.section.block.begin.terraform
@@ -3221,8 +3229,9 @@
     variable "name" {}
 #   ^^^^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^^^ keyword.declaration.terraform
-#            ^^^^^^ meta.string.terraform entity.name.label.terraform
+#            ^^^^^^ meta.string.terraform
 #            ^ punctuation.definition.string.begin.terraform
+#             ^^^^ entity.name.label.terraform
 #                 ^ punctuation.definition.string.end.terraform
 #                   ^^ meta.block.body.terraform
 #                   ^ punctuation.section.block.begin.terraform
@@ -3231,8 +3240,9 @@
     output "name"{}
 #   ^^^^^^^^^^^^^ meta.block.head.terraform
 #   ^^^^^^ keyword.declaration.terraform
-#          ^^^^^^ meta.string.terraform entity.name.label.terraform
+#          ^^^^^^ meta.string.terraform
 #          ^ punctuation.definition.string.begin.terraform
+#           ^^^^ entity.name.label.terraform
 #               ^ punctuation.definition.string.end.terraform
 #                ^^ meta.block.body.terraform
 #                ^ punctuation.section.block.begin.terraform

--- a/tests/syntax_test_scope.tf
+++ b/tests/syntax_test_scope.tf
@@ -2996,22 +2996,24 @@
 
     resource "aws_security_group" "example" {
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.terraform
-#                                          ^ - meta.type - meta.block meta.block
-#                                           ^^ meta.block.terraform - meta.type
 #   ^^^^^^^^ keyword.declaration.terraform
-#            ^ punctuation.definition.begin.terraform
+#            ^^^^^^^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#            ^ punctuation.definition.string.begin.terraform
 #             ^^^^^^^^^^^^^^^^^^ support.type.terraform
-#                               ^ punctuation.definition.end.terraform
-#                                 ^ punctuation.definition.begin.terraform
+#                               ^ punctuation.definition.string.end.terraform
+#                                 ^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#                                 ^ punctuation.definition.string.begin.terraform
 #                                  ^^^^^^^ entity.name.type.terraform
-#                                         ^ punctuation.definition.end.terraform
-#                                           ^ punctuation.section.block.begin.terraform
+#                                         ^ punctuation.definition.string.end.terraform
+#                                           ^ meta.block.terraform punctuation.section.block.begin.terraform
+
       name = "example"
-#    ^^^^^^^^^^^^^^^^^^ meta.block.terraform
+#     ^^^^^^^^^^^^^^^^ meta.block.terraform
 #     ^^^^ variable.declaration.terraform variable.other.readwrite.terraform
 #          ^ keyword.operator.assignment.terraform
-#            ^ string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#             ^^^^^^^^ string.quoted.double.terraform
+#            ^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#            ^ punctuation.definition.string.begin.terraform
+#                    ^ punctuation.definition.string.end.terraform
 
       dynamic "ingress" {
 #     ^^^^^^^^^^^^^^^^^ meta.block.terraform meta.type.terraform - meta.block meta.block

--- a/tests/syntax_test_symbol.tf
+++ b/tests/syntax_test_symbol.tf
@@ -1,0 +1,58 @@
+# SYNTAX TEST "Terraform.sublime-syntax"
+
+ terraform {
+#@@@@@@@@@ local-definition
+  backend "gcs" {
+# @@@@@@@@@@@@@ local-definition
+    prefix = "minecraft/state"
+    bucket = "terraform-larkworthy"
+  }
+}
+
+# You need to fill these locals out with the project, region and zone
+# Then to boot it up, run:-
+#   gcloud auth application-default login
+#   terraform init
+#   terraform apply
+ locals {
+#@@@@@@ local-definition
+  # The Google Cloud Project ID that will host and pay for your Minecraft server
+  project = "larkworthy-tester"
+  region  = "europe-west1"
+  zone    = "europe-west1-b"
+  # Allow members of an external Google group to turn on the server
+  # through the Cloud Console mobile app or https://console.cloud.google.com
+  # Create a group at https://groups.google.com/forum/#!creategroup
+  # and invite members by their email address.
+  enable_switch_access_group = 1
+  minecraft_switch_access_group = "minecraft-switchers-lark@googlegroups.com"
+}
+
+
+ provider "google" {
+#@@@@@@@@@@@@@@@@@ local-definition
+#          @@@@@@ global-definition
+  project = local.project
+  region  = local.region
+}
+
+# Create service account to run service with no permissions
+ resource "google_service_account" "minecraft" {
+#@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#                                   @@@@@@@@@ global-definition
+  account_id   = "minecraft"
+  display_name = <<EOT
+hello
+world
+EOT
+  test = "Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
+  x = <<EOT
+%{ for ip in aws_instance.example[*].private_ip ~}
+server ${ip}
+%{ endfor }
+EOT
+}
+
+    provider "name" {}
+#   @@@@@@@@@@@@@@@ local-definition
+#             @@@@ global-definition


### PR DESCRIPTION
These should be scoped like other strings. They are declared as `StringLit` and generally function like strings with regards to escape sequences but do not permit template interpolation. (In fact, normal identifiers may also be used.)

Docs: https://developer.hashicorp.com/terraform/language/syntax/configuration#arguments-and-blocks

Spec:
1. https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#structural-elements
2. https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#template-expressions