### PR TITLE
Add IPs and CIDR in strings

### DIFF
--- a/JSON (Terraform).sublime-syntax
+++ b/JSON (Terraform).sublime-syntax
@@ -16,6 +16,10 @@ contexts:
     - include: Packages/Terraform/Terraform.sublime-syntax#string-interpolation
     - include: Packages/Terraform/Terraform.sublime-syntax#aws-acl
 
+  strings:
+    - meta_prepend: true
+    - include: Packages/Terraform/Terraform.sublime-syntax#ip-address-strings
+
   line-comments:
     - meta_append: true
     - include: Packages/Terraform/Terraform.sublime-syntax#inline-comments

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -147,6 +147,7 @@ variables:
   zero_to_32: (?:3[0-2]|[12][0-9]|[0-9])
   zero_to_128: (?:12[0-8]|1[01][0-9]|[1-9][0-9]|[0-9])
   zero_to_255: (?:(?:25[0-5])|(?:2[0-4][0-9])|(?:1[0-9][0-9])|(?:[1-9][0-9])|[0-9])
+  zero_to_65535: (?:6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])
   ipv4: (?:(?:{{zero_to_255}}\.){3}{{zero_to_255}})
   ipv6: |-
     (?xi:
@@ -298,6 +299,7 @@ contexts:
   # https://www.terraform.io/docs/language/expressions/types.html
   # https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md#template-expressions
   string-literals:
+    - include: ip-address-strings
     - match: \"
       comment: Strings
       scope: punctuation.definition.string.begin.terraform
@@ -351,42 +353,37 @@ contexts:
     - meta_content_scope: source.terraform
     - include: string-interpolation-body
 
-  ipv4-at-start:
-    - match: \G{{ipv4}}\b
-      scope: meta.number.integer.other.terraform constant.numeric.ip-address.v4.terraform
-
-  ipv6-at-start:
-    - match: \G{{ipv6}}
-      scope: meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
-
-  ipv6-square-bracket-at-start:
-    - match: \G(\[){{ipv6}}(\])
-      scope: meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
+  ip-address-strings:
+    - match: (")({{ipv6}})(?:(/)({{zero_to_128}}))?(")
+      scope: meta.string.terraform string.quoted.double.terraform
       captures:
-        1: punctuation.definition.constant.begin.terraform
-        2: punctuation.definition.constant.end.terraform
-
-  ip-addresses-at-start:
-    - include: ipv6-at-start
-    - include: ipv4-at-start
-
-  ipv4-with-cidr-at-start:
-    - match: \G({{ipv4}})(?:(/)({{zero_to_32}}))?\b
+        1: punctuation.definition.string.begin.terraform
+        2: meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
+        3: punctuation.separator.terraform
+        4: constant.other.range.terraform
+        5: punctuation.definition.string.end.terraform
+    - match: (")((\[){{ipv6}}(\]))(?:(/)({{zero_to_128}})|(:)({{zero_to_65535}}))?(")
+      scope: meta.string.terraform string.quoted.double.terraform
       captures:
-        1: meta.number.integer.other.terraform constant.numeric.ip-address.v4.terraform
-        2: punctuation.separator.sequence.terraform
-        3: constant.other.range.terraform
-
-  ipv6-with-cidr-at-start:
-    - match: \G({{ipv6}})(?:(/)({{zero_to_128}})\b)?
+        1: punctuation.definition.string.begin.terraform
+        2: meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
+        3: punctuation.definition.constant.begin.terraform
+        4: punctuation.definition.constant.end.terraform
+        5: punctuation.separator.terraform
+        6: constant.other.range.terraform
+        7: punctuation.separator.terraform
+        8: constant.other.port.terraform
+        9: punctuation.definition.string.end.terraform
+    - match: (")({{ipv4}})(?:(/)({{zero_to_32}})|(:)({{zero_to_65535}}))?(")
+      scope: meta.string.terraform string.quoted.double.terraform
       captures:
-        1: meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
-        2: punctuation.separator.sequence.terraform
-        3: constant.other.range.terraform
-
-  ip-addresses-with-cidr-at-start:
-    - include: ipv6-with-cidr-at-start
-    - include: ipv4-with-cidr-at-start
+        1: punctuation.definition.string.begin.terraform
+        2: meta.number.integer.other.terraform constant.numeric.ip-address.v4.terraform
+        3: punctuation.separator.terraform
+        4: constant.other.range.terraform
+        5: punctuation.separator.terraform
+        6: constant.other.port.terraform
+        7: punctuation.definition.string.end.terraform
 
   # String Interpolation: ("${" | "${~") Expression ("}" | "~}"
   #

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -141,6 +141,29 @@ variables:
     | filemd1
     )
 
+  # IPs and CIDR
+  ## IPv6 pattern stolen lovingly from https://github.com/tijn/hosts.tmLanguage,
+  ## where Michael Lyons adapted them from David M. Szydek https://stackoverflow.com/a/17871737.
+  zero_to_32: (?:3[0-2]|[12][0-9]|[0-9])
+  zero_to_128: (?:12[0-8]|1[01][0-9]|[1-9][0-9]|[0-9])
+  zero_to_255: (?:(?:25[0-5])|(?:2[0-4][0-9])|(?:1[0-9][0-9])|(?:[1-9][0-9])|[0-9])
+  ipv4: (?:(?:{{zero_to_255}}\.){3}{{zero_to_255}})
+  ipv6: |-
+    (?xi:
+      (?:::(?:ffff(?::0{1,4}){0,1}:){0,1}{{ipv4}})          # ::255.255.255.255  ::ffff:255.255.255.255  ::ffff:0:255.255.255.255 (IPv4-mapped IPv6 addresses and IPv4-translated addresses)
+      |(?:(?:[0-9a-f]{1,4}:){1,4}:{{ipv4}})                 # 2001:db8:3:4::192.0.2.33  64:ff9b::192.0.2.33                       (IPv4-Embedded IPv6 Address)
+      |(?:fe80:(?::[0-9a-f]{1,4}){0,4}%[0-9a-z]{1,})        # fe80::7:8%eth0     fe80::7:8%1                                      (link-local IPv6 addresses with zone index)
+      |(?:(?:[0-9a-f]{1,4}:){7,7}    [0-9a-f]{1,4})         # 1:2:3:4:5:6:7:8
+      |   (?:[0-9a-f]{1,4}:      (?::[0-9a-f]{1,4}){1,6})   # 1::3:4:5:6:7:8     1::3:4:5:6:7:8   1::8
+      |(?:(?:[0-9a-f]{1,4}:){1,2}(?::[0-9a-f]{1,4}){1,5})   # 1::4:5:6:7:8       1:2::4:5:6:7:8   1:2::8
+      |(?:(?:[0-9a-f]{1,4}:){1,3}(?::[0-9a-f]{1,4}){1,4})   # 1::5:6:7:8         1:2:3::5:6:7:8   1:2:3::8
+      |(?:(?:[0-9a-f]{1,4}:){1,4}(?::[0-9a-f]{1,4}){1,3})   # 1::6:7:8           1:2:3:4::6:7:8   1:2:3:4::8
+      |(?:(?:[0-9a-f]{1,4}:){1,5}(?::[0-9a-f]{1,4}){1,2})   # 1::7:8             1:2:3:4:5::7:8   1:2:3:4:5::8
+      |(?:(?:[0-9a-f]{1,4}:){1,6}   :[0-9a-f]{1,4})         # 1::8               1:2:3:4:5:6::8   1:2:3:4:5:6::8
+      |(?:(?:[0-9a-f]{1,4}:){1,7}   :)                      # 1::                                 1:2:3:4:5:6:7::
+      |(?::(?:(?::[0-9a-f]{1,4}){1,7}|:))                   # ::2:3:4:5:6:7:8    ::2:3:4:5:6:7:8  ::8       ::
+    )
+
 contexts:
   main:
     - include: comments
@@ -291,6 +314,8 @@ contexts:
     - include: character-escapes
     - include: string-interpolation
     - include: aws-acl
+    - include: ip-addresses-with-cidr-at-start
+    - include: ipv6-square-bracket-at-start
 
   character-escapes:
     - match: '{{char_escapes}}'
@@ -325,6 +350,43 @@ contexts:
     - meta_scope: meta.interpolation.terraform
     - meta_content_scope: source.terraform
     - include: string-interpolation-body
+
+  ipv4-at-start:
+    - match: \G{{ipv4}}\b
+      scope: meta.number.integer.other.terraform constant.numeric.ip-address.v4.terraform
+
+  ipv6-at-start:
+    - match: \G{{ipv6}}
+      scope: meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
+
+  ipv6-square-bracket-at-start:
+    - match: \G(\[){{ipv6}}(\])
+      scope: meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
+      captures:
+        1: punctuation.definition.constant.begin.terraform
+        2: punctuation.definition.constant.end.terraform
+
+  ip-addresses-at-start:
+    - include: ipv6-at-start
+    - include: ipv4-at-start
+
+  ipv4-with-cidr-at-start:
+    - match: \G({{ipv4}})(?:(/)({{zero_to_32}}))?\b
+      captures:
+        1: meta.number.integer.other.terraform constant.numeric.ip-address.v4.terraform
+        2: punctuation.separator.sequence.terraform
+        3: constant.other.range.terraform
+
+  ipv6-with-cidr-at-start:
+    - match: \G({{ipv6}})(?:(/)({{zero_to_128}})\b)?
+      captures:
+        1: meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
+        2: punctuation.separator.sequence.terraform
+        3: constant.other.range.terraform
+
+  ip-addresses-with-cidr-at-start:
+    - include: ipv6-with-cidr-at-start
+    - include: ipv4-with-cidr-at-start
 
   # String Interpolation: ("${" | "${~") Expression ("}" | "~}"
   #

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -316,8 +316,6 @@ contexts:
     - include: character-escapes
     - include: string-interpolation
     - include: aws-acl
-    - include: ip-addresses-with-cidr-at-start
-    - include: ipv6-square-bracket-at-start
 
   character-escapes:
     - match: '{{char_escapes}}'

--- a/tests/syntax_test_scope.tf
+++ b/tests/syntax_test_scope.tf
@@ -298,6 +298,11 @@
 #      ^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
 #         ^ punctuation.definition.string.end.terraform
 
+      "deed"
+#     ^^^^^^ meta.string.terraform string.quoted.double.terraform - constant
+#     ^ punctuation.definition.string.begin.terraform
+#          ^ punctuation.definition.string.end.terraform
+
       "1:2:3:4:5:6:7:8"
 #     ^^^^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
 #     ^ punctuation.definition.string.begin.terraform

--- a/tests/syntax_test_scope.tf
+++ b/tests/syntax_test_scope.tf
@@ -271,15 +271,22 @@
 #     ^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
 #     ^ punctuation.definition.string.begin.terraform
 #      ^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v4.terraform
-#             ^ punctuation.separator.sequence.terraform
+#             ^ punctuation.separator.terraform
 #              ^^ constant.other.range.terraform
 #                ^ punctuation.definition.string.end.terraform
+
+      "1.2.3.4:8080"
+#     ^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#     ^ punctuation.definition.string.begin.terraform
+#      ^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v4.terraform
+#             ^ punctuation.separator.terraform
+#              ^^^^ constant.other.port.terraform
+#                  ^ punctuation.definition.string.end.terraform
 
       "1.2.3.4/33"
 #     ^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
 #     ^ punctuation.definition.string.begin.terraform
-#      ^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v4.terraform
-#             ^^^ - constant - punctuation
+#      ^^^^^^^^^^ - constant - punctuation
 #                ^ punctuation.definition.string.end.terraform
 
       "256.2.3.4"
@@ -297,20 +304,50 @@
 #      ^^^^^^^^^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
 #                     ^ punctuation.definition.string.end.terraform
 
+      "1:2:3:4:5:6:7:8:8080"
+#     ^^^^^^^^^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#     ^ punctuation.definition.string.begin.terraform
+#      ^^^^^^^^^^^^^^^^^^^^ - constant - punctuation
+#                          ^ punctuation.definition.string.end.terraform
+
       "1:2:3:4:5:6:7:8/128"
 #     ^^^^^^^^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
 #     ^ punctuation.definition.string.begin.terraform
 #      ^^^^^^^^^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
-#                     ^ punctuation.separator.sequence.terraform
+#                     ^ punctuation.separator.terraform
 #                      ^^^ constant.other.range.terraform
 #                         ^ punctuation.definition.string.end.terraform
 
       "1:2:3:4:5:6:7:8/129"
 #     ^^^^^^^^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
 #     ^ punctuation.definition.string.begin.terraform
-#      ^^^^^^^^^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
-#                     ^^^^ - constant - punctuation
+#      ^^^^^^^^^^^^^^^^^^^ - constant - punctuation
 #                         ^ punctuation.definition.string.end.terraform
+
+      "[1:2:3:4:5:6:7:8]/128"
+#     ^^^^^^^^^^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#     ^ punctuation.definition.string.begin.terraform
+#      ^^^^^^^^^^^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
+#      ^ punctuation.definition.constant.begin.terraform
+#                      ^ punctuation.definition.constant.end.terraform
+#                       ^ punctuation.separator.terraform
+#                        ^^^ constant.other.range.terraform
+#                           ^ punctuation.definition.string.end.terraform
+
+      "[1:2:3:4:5:6:7:8]:8080"
+#     ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#     ^ punctuation.definition.string.begin.terraform
+#      ^^^^^^^^^^^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
+#      ^ punctuation.definition.constant.begin.terraform
+#                      ^ punctuation.definition.constant.end.terraform
+#                       ^ punctuation.separator.terraform
+#                        ^^^^ constant.other.port.terraform
+#                            ^ punctuation.definition.string.end.terraform
+
+      "[1:2:3:4:5:6:7:8]/129"
+#     ^^^^^^^^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#     ^ punctuation.definition.string.begin.terraform
+#      ^^^^^^^^^^^^^^^^^^^^^ - constant - punctuation
 
 /////
 // Unclosed strings

--- a/tests/syntax_test_scope.tf
+++ b/tests/syntax_test_scope.tf
@@ -256,6 +256,62 @@
 #                                     ^^^^^^^^^^ constant.character.escape.terraform
 #                                               ^ punctuation.definition.string.end.terraform
 
+
+/////
+// Matches IPs and CIDR
+/////
+
+      "1.2.3.4"
+#     ^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#     ^ punctuation.definition.string.begin.terraform
+#      ^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v4.terraform
+#             ^ punctuation.definition.string.end.terraform
+
+      "1.2.3.4/32"
+#     ^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#     ^ punctuation.definition.string.begin.terraform
+#      ^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v4.terraform
+#             ^ punctuation.separator.sequence.terraform
+#              ^^ constant.other.range.terraform
+#                ^ punctuation.definition.string.end.terraform
+
+      "1.2.3.4/33"
+#     ^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#     ^ punctuation.definition.string.begin.terraform
+#      ^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v4.terraform
+#             ^^^ - constant - punctuation
+#                ^ punctuation.definition.string.end.terraform
+
+      "256.2.3.4"
+#     ^^^^^^^^^^^ - constant
+
+      "::1"
+#     ^^^^^ meta.string.terraform string.quoted.double.terraform
+#     ^ punctuation.definition.string.begin.terraform
+#      ^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
+#         ^ punctuation.definition.string.end.terraform
+
+      "1:2:3:4:5:6:7:8"
+#     ^^^^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#     ^ punctuation.definition.string.begin.terraform
+#      ^^^^^^^^^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
+#                     ^ punctuation.definition.string.end.terraform
+
+      "1:2:3:4:5:6:7:8/128"
+#     ^^^^^^^^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#     ^ punctuation.definition.string.begin.terraform
+#      ^^^^^^^^^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
+#                     ^ punctuation.separator.sequence.terraform
+#                      ^^^ constant.other.range.terraform
+#                         ^ punctuation.definition.string.end.terraform
+
+      "1:2:3:4:5:6:7:8/129"
+#     ^^^^^^^^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
+#     ^ punctuation.definition.string.begin.terraform
+#      ^^^^^^^^^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v6.terraform
+#                     ^^^^ - constant - punctuation
+#                         ^ punctuation.definition.string.end.terraform
+
 /////
 // Unclosed strings
 /////

--- a/tests/syntax_test_scope.tf
+++ b/tests/syntax_test_scope.tf
@@ -303,6 +303,11 @@
 #     ^ punctuation.definition.string.begin.terraform
 #          ^ punctuation.definition.string.end.terraform
 
+      "deed:10:10"
+#     ^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform - constant
+#     ^ punctuation.definition.string.begin.terraform
+#                ^ punctuation.definition.string.end.terraform
+
       "1:2:3:4:5:6:7:8"
 #     ^^^^^^^^^^^^^^^^^ meta.string.terraform string.quoted.double.terraform
 #     ^ punctuation.definition.string.begin.terraform

--- a/tests/syntax_test_scope.tf
+++ b/tests/syntax_test_scope.tf
@@ -3551,6 +3551,20 @@ resource "aws_iam_role_policy" "attach-inline-policy-1" {
 #                                                                         ^ punctuation.section.interpolation.end.terraform
 #                                                                              ^ string.quoted.double.json  punctuation.definition.string.end.json - variable
 #                                                                               ^ punctuation.separator.sequence.json
+
+                "IP": "1.2.3.4",
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.body.terraform meta.function-call.arguments.terraform meta.parens.terraform meta.mapping.value.json meta.sequence.json
+#^^^^^^^^^^^^^^^ meta.mapping.json
+#               ^^^^ meta.mapping.key.json string.quoted.double.json
+#               ^ punctuation.definition.string.begin.json
+#                  ^ punctuation.definition.string.end.json
+#                   ^^ meta.mapping.json
+#                   ^ punctuation.separator.key-value.json
+#                     ^^^^^^^^^ meta.mapping.value.json meta.string.terraform string.quoted.double.terraform
+#                     ^ punctuation.definition.string.begin.terraform
+#                      ^^^^^^^ meta.number.integer.other.terraform constant.numeric.ip-address.v4.terraform
+#                             ^ punctuation.definition.string.end.terraform
+#                              ^ meta.mapping.json punctuation.separator.sequence.json
                 "Effect": "Allow"
             }
         ]


### PR DESCRIPTION
As suggested at https://github.com/SublimeText/Terraform/pull/67#discussion_r2072675849

> Conveying IP/CIDR in strings makes sense

And directly opposed to https://github.com/SublimeText/Terraform/commit/01eba127fe3411a5c53c04866172d84d294b9e59

> We don't need or want to interpret string literals as their content is
none of our business and has no explicit or implicit meaning.

:man_shrugging: 