### PR TITLE
Scope hanging bracket content in plan output

### DIFF
--- a/Terraform Plan.sublime-syntax
+++ b/Terraform Plan.sublime-syntax
@@ -11,6 +11,8 @@ file_extensions:
   - tf.plan
 
 contexts:
+  prototype:
+    - include: comments
 
   main:
     - include: comments
@@ -23,6 +25,15 @@ contexts:
       push:
         - meta_scope: comment.line.number-sign.terraform
         - include: pop-eol
+
+  annotations:
+    - meta_include_prototype: false
+    - match: ->
+      scope: keyword.operator.assignment.terraform
+    - match: \(known after apply\)$
+      scope: comment.block.terraform
+    - match: \bnull$
+      scope: constant.language.null.terraform
 
   diffs:
     - match: ^\+/-
@@ -40,37 +51,38 @@ contexts:
     - match: ^-
       scope: punctuation.definition.deleted.diff
       push: line-deleted
-
-  annotations:
-    - match: ->
-      scope: keyword.operator.assignment.terraform
-    - match: \(known after apply\)$
-      scope: comment.block.terraform
-    - match: \bnull$
-      scope: constant.language.null.terraform
+    - match: \[$\n?
+      push: closing-bracket
+    - match: \{$\n?
+      push: closing-brace
 
   line-deleted:
     - meta_scope: markup.deleted.diff
+    - include: pop-eol-bracket-deleted
     - include: pop-eol
     - include: annotations
 
   line-inserted:
     - meta_scope: markup.inserted.diff
+    - include: pop-eol-bracket-inserted
     - include: pop-eol
     - include: annotations
 
   line-changed:
     - meta_scope: markup.changed.updated-in-place.diff
+    - include: pop-eol-bracket-changed
     - include: pop-eol
     - include: annotations
 
   line-created-then-destroyed:
     - meta_scope: markup.changed.created-then-destroyed.diff
+    - include: pop-eol-bracket-changed
     - include: pop-eol
     - include: annotations
 
   line-destroyed-then-created:
     - meta_scope: markup.changed.destroyed-then-created.diff
+    - include: pop-eol-bracket-changed
     - include: pop-eol
     - include: annotations
 
@@ -78,6 +90,67 @@ contexts:
     - meta_scope: comment.line.diff
     - include: pop-eol
     - include: annotations
+
+  closing-bracket:
+    - match: ^(?=\s*\])
+      pop: 1
+    - include: diffs
+
+  closing-brace:
+    - match: ^\s*\}
+      pop: 1
+    - include: diffs
+
+  pop-eol-bracket-deleted:
+    - match: \[$\n?
+      set: closing-bracket-deleted
+    - match: \{$\n?
+      set: closing-brace-deleted
+
+  closing-bracket-deleted:
+    - match: ^(?=\s*\])
+      set: line-deleted
+    - include: diffs
+
+  closing-brace-deleted:
+    - match: ^\s*\}
+      scope: markup.deleted.diff
+      pop: 1
+    - include: diffs
+
+  pop-eol-bracket-inserted:
+    - match: \[$\n?
+      set: closing-bracket-inserted
+    - match: \{$\n?
+      set: closing-brace-inserted
+
+  closing-bracket-inserted:
+    - match: ^(?=\s*\])
+      set: line-inserted
+    - include: diffs
+
+  closing-brace-inserted:
+    - match: ^(?=\s*\})
+      set: line-inserted
+    - include: diffs
+
+  pop-eol-bracket-changed:
+    - match: \[$\n?
+      set: closing-bracket-changed
+    - match: \{$\n?
+      set: closing-brace-changed
+
+  closing-bracket-changed:
+    - match: ^\s*\]
+      scope: markup.changed.diff
+      pop: 1
+    - include: diffs
+
+  closing-brace-changed:
+    - match: ^\s*\}
+      scope: markup.changed.diff
+      pop: 1
+    - include: diffs
 
   summary:
     - match: ^(?=Plan:[ ]\d)

--- a/Terraform Plan.sublime-syntax
+++ b/Terraform Plan.sublime-syntax
@@ -30,9 +30,9 @@ contexts:
     - meta_include_prototype: false
     - match: ->
       scope: keyword.operator.assignment.terraform
-    - match: \(known after apply\)$
+    - match: \(known after apply\)
       scope: comment.block.terraform
-    - match: \bnull$
+    - match: \bnull\b
       scope: constant.language.null.terraform
 
   diffs:

--- a/Terraform Plan.sublime-syntax
+++ b/Terraform Plan.sublime-syntax
@@ -52,37 +52,37 @@ contexts:
       scope: punctuation.definition.deleted.diff
       push: line-deleted
     - match: \[$\n?
-      push: closing-bracket
+      push: bracket-body
     - match: \{$\n?
-      push: closing-brace
+      push: brace-body
 
   line-deleted:
     - meta_scope: markup.deleted.diff
-    - include: pop-eol-bracket-deleted
+    - include: line-deleted.hanging-eol-brackets
     - include: pop-eol
     - include: annotations
 
   line-inserted:
     - meta_scope: markup.inserted.diff
-    - include: pop-eol-bracket-inserted
+    - include: line-inserted.hanging-eol-brackets
     - include: pop-eol
     - include: annotations
 
   line-changed:
     - meta_scope: markup.changed.updated-in-place.diff
-    - include: pop-eol-bracket-changed
+    - include: line-changed.hanging-eol-brackets
     - include: pop-eol
     - include: annotations
 
   line-created-then-destroyed:
     - meta_scope: markup.changed.created-then-destroyed.diff
-    - include: pop-eol-bracket-changed
+    - include: line-changed.hanging-eol-brackets
     - include: pop-eol
     - include: annotations
 
   line-destroyed-then-created:
     - meta_scope: markup.changed.destroyed-then-created.diff
-    - include: pop-eol-bracket-changed
+    - include: line-changed.hanging-eol-brackets
     - include: pop-eol
     - include: annotations
 
@@ -91,62 +91,62 @@ contexts:
     - include: pop-eol
     - include: annotations
 
-  closing-bracket:
+  bracket-body:
     - match: ^(?=\s*\])
       pop: 1
     - include: diffs
 
-  closing-brace:
+  brace-body:
     - match: ^\s*\}
       pop: 1
     - include: diffs
 
-  pop-eol-bracket-deleted:
+  line-deleted.hanging-eol-brackets:
     - match: \[$\n?
-      set: closing-bracket-deleted
+      set: line-deleted.bracket-body
     - match: \{$\n?
-      set: closing-brace-deleted
+      set: line-deleted.brace-body
 
-  closing-bracket-deleted:
+  line-deleted.bracket-body:
     - match: ^(?=\s*\])
       set: line-deleted
     - include: diffs
 
-  closing-brace-deleted:
+  line-deleted.brace-body:
     - match: ^\s*\}
       scope: markup.deleted.diff
       pop: 1
     - include: diffs
 
-  pop-eol-bracket-inserted:
+  line-inserted.hanging-eol-brackets:
     - match: \[$\n?
-      set: closing-bracket-inserted
+      set: line-inserted.bracket-body
     - match: \{$\n?
-      set: closing-brace-inserted
+      set: line-inserted.brace-body
 
-  closing-bracket-inserted:
+  line-inserted.bracket-body:
     - match: ^(?=\s*\])
       set: line-inserted
     - include: diffs
 
-  closing-brace-inserted:
+  line-inserted.brace-body:
     - match: ^(?=\s*\})
       set: line-inserted
     - include: diffs
 
-  pop-eol-bracket-changed:
+  line-changed.hanging-eol-brackets:
     - match: \[$\n?
-      set: closing-bracket-changed
+      set: line-changed.bracket-body
     - match: \{$\n?
-      set: closing-brace-changed
+      set: line-changed.brace-body
 
-  closing-bracket-changed:
+  line-changed.bracket-body:
     - match: ^\s*\]
       scope: markup.changed.diff
       pop: 1
     - include: diffs
 
-  closing-brace-changed:
+  line-changed.brace-body:
     - match: ^\s*\}
       scope: markup.changed.diff
       pop: 1

--- a/tests/syntax_test_scope.tfplan
+++ b/tests/syntax_test_scope.tfplan
@@ -15,7 +15,7 @@ Terraform will perform the following actions:
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.changed.destroyed-then-created.diff
 #^^ punctuation.definition.changed.diff
 +       allow_overwrite = (known after apply)
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.inserted.diff
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.inserted.diff - markup markup
 #                         ^^^^^^^^^^^^^^^^^^^ comment.block.terraform
 !       fqdn            = "autodiscover.example.com" -> (known after apply)
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.changed.updated-in-place.diff
@@ -32,13 +32,13 @@ Terraform will perform the following actions:
         # (4 unchanged attributes hidden)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - markup
     }
-# ^^^^ - markup
+#^^^^ markup.changed.diff
 
   # aws_route53_record_cname_lyncdiscover_example_com will be destroyed
 -   resource "aws_route53_record" "cname_lyncdiscover_example_com_old" {
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.deleted.diff
 -       fqdn    = "lyncdiscover.example.com" -> null
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.deleted.diff
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.deleted.diff - markup markup
 #                                            ^^ keyword.operator.assignment.terraform
 #                                               ^^^^ constant.language.null.terraform
 -       id      = "ABCDEABCDEABCDEA_lyncdiscover_CNAME" -> null
@@ -50,15 +50,19 @@ Terraform will perform the following actions:
 -           "webdir.online.lync.com.",
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.deleted.diff
         ] -> null
+#^^^^^^^^^^^^^^^^ markup.deleted.diff - markup markup
+#         ^^ keyword.operator.assignment.terraform
+#            ^^^^ constant.language.null.terraform
 -       ttl     = 7200 -> null
 -       type    = "CNAME" -> null
 -       zone_id = "ABCDEABCDEABCDEA" -> null
     }
+#^^^^ markup.deleted.diff - markup markup
 
   # aws_route53_record_cname_lyncdiscover_example_com will be created
 +   resource "aws_route53_record" "cname_lyncdiscover_example_com_new" {
 +       fqdn    = (known after apply)
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.inserted.diff
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.inserted.diff - markup markup
 #                 ^^^^^^^^^^^^^^^^^^^ comment.block.terraform
 +       id      = (known after apply)
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.inserted.diff
@@ -68,12 +72,13 @@ Terraform will perform the following actions:
 #                 ^^^^^^^^^^^^^^^^^^^ comment.block.terraform
 +       records = [
 +           "webdir.online.lync.com.",
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.inserted.diff
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.inserted.diff - markup markup
         ]
 +       ttl     = 7200
 +       type    = "CNAME"
 +       zone_id = "ABCDEABCDEABCDEA"
     }
+#^^^^ markup.inserted.diff - markup markup
 
   # aws_route53_record_zone_example_com will be updated in-place
 !   resource "aws_route53_record" "cname_autodiscover_example_com" {
@@ -84,12 +89,16 @@ Terraform will perform the following actions:
         id            = "ABCDEABCDEABCDEA"
         name          = "example.com"
         tags          = {
+#^^^^^^^^^^^^^^^^^^^^^^^^ - markup
             "Provisioner" = "Terraform"
             "System"      = "example"
             "Workspace"   = "production"
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - markup
         }
+#^^^^^^^^ - markup
         # (3 unchanged attributes hidden)
     }
+#^^^^ markup.changed.diff - markup markup
 
 Plan: 2 to add, 1 to change, 2 to destroy.
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.summary.terraform


### PR DESCRIPTION
It bugs me that the plan output from #51 has hanging bits that don't have, e.g. a `-` at BOL below:

```
    ] -> null
```

This PR looks for `{` and `[` at EOL and pairs them to their closing brackets without meta scopes. If opening brackets need detection mid-line, this task is probably impossible.

|Before|After|
|-|-|
|<img width="765" height="1081" alt="Screenshot_20260121_125321" src="https://github.com/user-attachments/assets/aee7b277-1cd9-49e1-aafd-f1d05f2fdd2c" />|<img width="772" height="1083" alt="Screenshot_20260103_170850" src="https://github.com/user-attachments/assets/56291832-a936-4219-b4f7-58b59a620bca" />|
